### PR TITLE
feat(ui): redesign dashboard and cats page UI

### DIFF
--- a/app/dashboard/cats/page.tsx
+++ b/app/dashboard/cats/page.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { motion } from "framer-motion";
 import {
   Plus,
-  ChevronRight,
-  Clock,
-  Timer,
   ScanLine,
   Upload,
   Loader2,
@@ -26,17 +23,9 @@ import {
 } from "@/lib/mockData";
 import {
   getStatusColor,
-  getStatusLabel,
   calculateAge,
   generateId,
 } from "@/lib/formatters";
-
-// Mock last seen data (in a real app this would come from the backend)
-const mockLastSeen: Record<string, string> = {
-  "1": "12 min ago",
-  "2": "34 min ago",
-  "3": "2 hr ago",
-};
 
 interface CatFormData {
   name: string;
@@ -80,7 +69,6 @@ export default function CatsPage() {
       newErrors.name = "Cat name is required";
     }
 
-    // Check for duplicate RFID
     const existingRfids = cats.map((c) => getCatDetailsById(c.id)?.rfidTag).filter(Boolean);
     if (formData.rfidTag && existingRfids.includes(formData.rfidTag)) {
       newErrors.rfidTag = "Already registered";
@@ -94,8 +82,6 @@ export default function CatsPage() {
     if (!validateForm()) return;
 
     setIsSaving(true);
-
-    // Mock delay
     await new Promise((resolve) => setTimeout(resolve, 1500));
 
     const newCat: Cat = {
@@ -124,52 +110,53 @@ export default function CatsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-[#FDFAF6] pb-24">
+    <div className="min-h-screen bg-litter-bg pb-24">
       <TopBar />
       <ToastContainer toasts={toasts} onClose={removeToast} />
 
-      <main className="pt-20 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto">
+      <main className="pt-20 px-4 sm:px-6 lg:px-8 max-w-6xl mx-auto">
         {/* Header */}
         <motion.section
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
-          className="mb-6 flex items-start justify-between"
+          className="mb-8 pt-6 flex items-end justify-between"
         >
           <div>
-            <h1 className="font-display text-2xl sm:text-3xl font-bold text-[#1C1C1C] mb-1">
+            <h1 className="font-display text-2xl sm:text-3xl lg:text-4xl font-bold text-litter-text mb-1">
               My Cats
             </h1>
-            <p className="text-[#6B7280] text-sm sm:text-base">
+            <p className="text-litter-muted text-sm sm:text-base">
               Manage your feline companions
             </p>
           </div>
           <button
             onClick={() => setIsModalOpen(true)}
-            className="flex items-center gap-2 px-4 py-2.5 bg-[#1E6B5E] text-white rounded-lg font-medium hover:bg-[#165a4e] active:bg-[#124a40] transition-colors shadow-sm"
+            className="flex items-center gap-2 px-5 py-2.5 bg-litter-primary text-white rounded-full font-semibold hover:bg-[#165a4e] active:bg-[#124a40] transition-colors shadow-sm text-sm"
           >
-            <Plus className="w-5 h-5" />
-            <span className="hidden sm:inline">Add Cat</span>
+            + Add Cat
           </button>
         </motion.section>
 
-        {/* Cats List */}
-        <section className="space-y-4">
+        {/* Cats Grid */}
+        <section className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
           {cats.length === 0 ? (
-            <EmptyState
-              icon={CatIcon}
-              title="No cats yet"
-              description="Add your first cat to start monitoring their health."
-              action={
-                <button
-                  onClick={() => setIsModalOpen(true)}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-[#1E6B5E] text-white rounded-lg font-medium hover:bg-[#165a4e] transition-colors"
-                >
-                  <Plus className="w-5 h-5" />
-                  Add Your First Cat
-                </button>
-              }
-            />
+            <div className="col-span-full">
+              <EmptyState
+                icon={CatIcon}
+                title="No cats yet"
+                description="Add your first cat to start monitoring their health."
+                action={
+                  <button
+                    onClick={() => setIsModalOpen(true)}
+                    className="flex items-center gap-2 px-4 py-2.5 bg-litter-primary text-white rounded-xl font-medium hover:bg-[#165a4e] transition-colors"
+                  >
+                    <Plus className="w-5 h-5" />
+                    Add Your First Cat
+                  </button>
+                }
+              />
+            </div>
           ) : (
             cats.map((cat, index) => (
               <CatCard key={cat.id} cat={cat} index={index} />
@@ -194,27 +181,18 @@ export default function CatsPage() {
           {/* Photo Upload */}
           <div className="flex flex-col items-center">
             <div className="relative">
-              <div className="w-24 h-24 rounded-full bg-[#D4EDE8] flex items-center justify-center overflow-hidden">
+              <div className="w-24 h-24 rounded-full bg-litter-primary-light flex items-center justify-center overflow-hidden">
                 {formData.photo ? (
-                  <img
-                    src={formData.photo}
-                    alt="Preview"
-                    className="w-full h-full object-cover"
-                  />
+                  <img src={formData.photo} alt="Preview" className="w-full h-full object-cover" />
                 ) : (
-                  <span className="text-3xl font-display font-bold text-[#1E6B5E]">
+                  <span className="text-3xl font-display font-bold text-litter-primary">
                     {formData.name.charAt(0).toUpperCase() || "?"}
                   </span>
                 )}
               </div>
-              <label className="absolute bottom-0 right-0 w-8 h-8 bg-[#1E6B5E] rounded-full flex items-center justify-center cursor-pointer hover:bg-[#165a4e] transition-colors shadow-md">
+              <label className="absolute bottom-0 right-0 w-8 h-8 bg-litter-primary rounded-full flex items-center justify-center cursor-pointer hover:bg-[#165a4e] transition-colors shadow-md">
                 <Upload className="w-4 h-4 text-white" />
-                <input
-                  type="file"
-                  accept="image/*"
-                  onChange={handleFileChange}
-                  className="hidden"
-                />
+                <input type="file" accept="image/*" onChange={handleFileChange} className="hidden" />
               </label>
             </div>
             <p className="text-xs text-gray-500 mt-2">Tap to upload photo</p>
@@ -228,95 +206,69 @@ export default function CatsPage() {
             <input
               type="text"
               value={formData.name}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, name: e.target.value }))
-              }
+              onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
               placeholder="e.g. Whiskers"
-              className={`w-full px-4 py-3 rounded-xl border ${
-                errors.name ? "border-red-500" : "border-[#E8E2D9]"
-              } focus:outline-none focus:ring-2 focus:ring-[#1E6B5E] focus:border-transparent transition-all`}
+              className={`w-full px-4 py-3 rounded-xl border ${errors.name ? "border-red-500" : "border-litter-border"} focus:outline-none focus:ring-2 focus:ring-litter-primary focus:border-transparent transition-all`}
             />
-            {errors.name && (
-              <p className="text-red-500 text-xs mt-1">{errors.name}</p>
-            )}
+            {errors.name && <p className="text-red-500 text-xs mt-1">{errors.name}</p>}
           </div>
 
           {/* Breed */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
-              Breed
-            </label>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">Breed</label>
             <input
               type="text"
               value={formData.breed}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, breed: e.target.value }))
-              }
+              onChange={(e) => setFormData((prev) => ({ ...prev, breed: e.target.value }))}
               placeholder="e.g. Domestic Shorthair"
-              className="w-full px-4 py-3 rounded-xl border border-[#E8E2D9] focus:outline-none focus:ring-2 focus:ring-[#1E6B5E] focus:border-transparent transition-all"
+              className="w-full px-4 py-3 rounded-xl border border-litter-border focus:outline-none focus:ring-2 focus:ring-litter-primary focus:border-transparent transition-all"
             />
           </div>
 
           {/* Date of Birth */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
-              Date of Birth
-            </label>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">Date of Birth</label>
             <input
               type="month"
               value={formData.dob}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, dob: e.target.value }))
-              }
-              className="w-full px-4 py-3 rounded-xl border border-[#E8E2D9] focus:outline-none focus:ring-2 focus:ring-[#1E6B5E] focus:border-transparent transition-all"
+              onChange={(e) => setFormData((prev) => ({ ...prev, dob: e.target.value }))}
+              className="w-full px-4 py-3 rounded-xl border border-litter-border focus:outline-none focus:ring-2 focus:ring-litter-primary focus:border-transparent transition-all"
             />
           </div>
 
           {/* Weight */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
-              Weight (kg)
-            </label>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">Weight (kg)</label>
             <input
               type="number"
               step="0.1"
               value={formData.weightKg}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, weightKg: e.target.value }))
-              }
+              onChange={(e) => setFormData((prev) => ({ ...prev, weightKg: e.target.value }))}
               placeholder="e.g. 4.2"
-              className="w-full px-4 py-3 rounded-xl border border-[#E8E2D9] focus:outline-none focus:ring-2 focus:ring-[#1E6B5E] focus:border-transparent transition-all"
+              className="w-full px-4 py-3 rounded-xl border border-litter-border focus:outline-none focus:ring-2 focus:ring-litter-primary focus:border-transparent transition-all"
             />
           </div>
 
           {/* RFID Tag */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
-              RFID Tag ID
-            </label>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">RFID Tag ID</label>
             <div className="relative">
               <input
                 type="text"
                 value={formData.rfidTag}
-                onChange={(e) =>
-                  setFormData((prev) => ({ ...prev, rfidTag: e.target.value }))
-                }
+                onChange={(e) => setFormData((prev) => ({ ...prev, rfidTag: e.target.value }))}
                 placeholder="Scan or enter RFID tag"
-                className={`w-full px-4 py-3 pr-12 rounded-xl border ${
-                  errors.rfidTag ? "border-red-500" : "border-[#E8E2D9]"
-                } focus:outline-none focus:ring-2 focus:ring-[#1E6B5E] focus:border-transparent transition-all`}
+                className={`w-full px-4 py-3 pr-12 rounded-xl border ${errors.rfidTag ? "border-red-500" : "border-litter-border"} focus:outline-none focus:ring-2 focus:ring-litter-primary focus:border-transparent transition-all`}
               />
               <button
                 type="button"
                 title="Tap the RFID button on your LitterSense device to auto-fill"
-                className="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 text-gray-400 hover:text-[#1E6B5E] transition-colors"
+                className="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 text-gray-400 hover:text-litter-primary transition-colors"
               >
                 <ScanLine className="w-5 h-5" />
               </button>
             </div>
-            {errors.rfidTag && (
-              <p className="text-red-500 text-xs mt-1">{errors.rfidTag}</p>
-            )}
+            {errors.rfidTag && <p className="text-red-500 text-xs mt-1">{errors.rfidTag}</p>}
             <p className="text-xs text-gray-400 mt-1">
               Tap the RFID button on your LitterSense device to auto-fill
             </p>
@@ -339,7 +291,7 @@ export default function CatsPage() {
               type="button"
               onClick={handleSave}
               disabled={isSaving}
-              className="flex-1 px-4 py-3 rounded-xl bg-[#1E6B5E] text-white font-medium hover:bg-[#165a4e] active:bg-[#124a40] transition-colors disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              className="flex-1 px-4 py-3 rounded-xl bg-litter-primary text-white font-medium hover:bg-[#165a4e] active:bg-[#124a40] transition-colors disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             >
               {isSaving ? (
                 <>
@@ -357,18 +309,25 @@ export default function CatsPage() {
   );
 }
 
-// Cat Card Component
+// ── Cat Card ────────────────────────────────────────────────────────────────
 interface CatCardProps {
   cat: Cat;
   index: number;
 }
 
+const badgeLabel: Record<string, string> = { healthy: "HEALTHY", watch: "WATCH", alert: "ALERT" };
+
 function CatCard({ cat, index }: CatCardProps) {
   const details = getCatDetailsById(cat.id);
   const stats = mockStats[cat.id];
   const statusColors = getStatusColor(cat.status);
-  const statusLabel = getStatusLabel(cat.status);
-  const lastSeen = mockLastSeen[cat.id] || "Unknown";
+
+  const dotColor =
+    cat.status === "healthy"
+      ? "bg-green-500"
+      : cat.status === "watch"
+      ? "bg-amber-500"
+      : "bg-red-500";
 
   return (
     <motion.div
@@ -377,61 +336,50 @@ function CatCard({ cat, index }: CatCardProps) {
       transition={{ duration: 0.4, delay: index * 0.1 }}
     >
       <Link href={`/dashboard/cats/${cat.id}`}>
-        <div
-          className={`bg-white rounded-xl shadow-sm border border-[#E8E2D9] overflow-hidden hover:shadow-md active:scale-[0.99] transition-all cursor-pointer`}
-        >
-          {/* Left border indicator */}
-          <div className={`absolute left-0 top-0 bottom-0 w-1 ${statusColors.indicator}`} />
-
-          <div className="p-4 flex items-center gap-4">
+        <div className="bg-white rounded-2xl shadow-sm border border-litter-border hover:shadow-md hover:-translate-y-0.5 active:scale-[0.99] transition-all cursor-pointer overflow-hidden">
+          {/* Card top */}
+          <div className="p-5 flex items-center gap-4">
             {/* Avatar */}
-            <div className="w-14 h-14 rounded-full bg-[#D4EDE8] flex items-center justify-center text-[#1E6B5E] font-semibold text-xl shrink-0">
+            <div className="w-14 h-14 rounded-full bg-litter-primary-light flex items-center justify-center text-litter-primary font-bold text-xl shrink-0">
               {cat.avatar ? (
-                <img
-                  src={cat.avatar}
-                  alt={cat.name}
-                  className="w-full h-full rounded-full object-cover"
-                />
+                <img src={cat.avatar} alt={cat.name} className="w-full h-full rounded-full object-cover" />
               ) : (
                 cat.name.charAt(0).toUpperCase()
               )}
             </div>
 
-            {/* Info */}
+            {/* Name + breed */}
             <div className="flex-1 min-w-0">
-              <h3 className="font-semibold text-[#1C1C1C] text-lg">{cat.name}</h3>
-              <p className="text-sm text-gray-500">
+              <h3 className="font-bold text-litter-text text-lg leading-tight">{cat.name}</h3>
+              <p className="text-sm text-litter-muted mt-0.5">
                 {details?.breed || "Unknown breed"} · {details ? calculateAge(details.dob) : "Unknown age"}
               </p>
-
-              {/* Status badge */}
-              <div className="flex items-center gap-2 mt-2">
-                <span
-                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${statusColors.bg} ${statusColors.text}`}
-                >
-                  {statusLabel}
-                </span>
-              </div>
-
-              {/* Mini stats */}
-              <div className="flex items-center gap-4 mt-3 text-xs text-gray-500">
-                <span className="flex items-center gap-1">
-                  <Clock className="w-3.5 h-3.5" />
-                  Visits today: {stats?.visits || 0}
-                </span>
-                <span className="flex items-center gap-1">
-                  <Timer className="w-3.5 h-3.5" />
-                  Avg: {stats?.avgDuration || "--"}
-                </span>
-                <span className="hidden sm:flex items-center gap-1">
-                  <span className="w-1.5 h-1.5 rounded-full bg-gray-400" />
-                  Last: {lastSeen}
-                </span>
-              </div>
             </div>
 
-            {/* Chevron */}
-            <ChevronRight className="w-5 h-5 text-gray-400 shrink-0" />
+            {/* Status badge */}
+            <div className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold ${statusColors.bg} ${statusColors.text} shrink-0`}>
+              <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+              {badgeLabel[cat.status]}
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="border-t border-litter-border mx-5" />
+
+          {/* Stats row */}
+          <div className="grid grid-cols-3 divide-x divide-litter-border px-5 py-4">
+            <div className="pr-4">
+              <p className="text-[10px] font-semibold text-litter-muted uppercase tracking-wider mb-1">Visits</p>
+              <p className="font-bold text-litter-text text-lg">{stats?.visits ?? "--"}</p>
+            </div>
+            <div className="px-4">
+              <p className="text-[10px] font-semibold text-litter-muted uppercase tracking-wider mb-1">Duration</p>
+              <p className="font-bold text-litter-text text-lg">{stats?.avgDuration?.replace("s", "") ?? "--"}</p>
+            </div>
+            <div className="pl-4">
+              <p className="text-[10px] font-semibold text-litter-muted uppercase tracking-wider mb-1">Last Visit</p>
+              <p className="font-bold text-litter-text text-lg">{stats?.lastVisit ?? "--"}</p>
+            </div>
           </div>
         </div>
       </Link>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Clock, Timer, Wind, BarChart2, AlertTriangle, X } from "lucide-react";
+import { Clock, Timer, Wind, BarChart2, AlertTriangle } from "lucide-react";
 import { TopBar } from "@/components/layout/TopBar";
 import { BottomNav } from "@/components/layout/BottomNav";
 import { StatCard } from "@/components/ui/StatCard";
@@ -29,20 +29,41 @@ const formatDate = () => {
 
 const getAirQualityStatus = (quality: string) => {
   switch (quality) {
-    case "Normal":
-      return "healthy";
-    case "Elevated":
-      return "watch";
-    case "Poor":
-      return "alert";
-    default:
-      return "normal";
+    case "Normal": return "healthy";
+    case "Elevated": return "watch";
+    case "Poor": return "alert";
+    default: return "normal" as const;
   }
 };
 
 const getLitterLevelStatus = (level: number) => {
   if (level >= 80) return "alert";
   if (level >= 60) return "watch";
+  return "healthy";
+};
+
+const getVisitsStatus = (visits: number) => {
+  if (visits > 6) return "watch";
+  if (visits > 8) return "alert";
+  return "healthy";
+};
+
+const getVisitsLabel = (visits: number) => {
+  if (visits > 6) return "Unusual";
+  return "Healthy";
+};
+
+const getDurationLabel = (duration: string) => {
+  const mins = parseInt(duration);
+  if (mins >= 5) return "High";
+  if (mins >= 3) return "Unusual";
+  return "Healthy";
+};
+
+const getDurationStatus = (duration: string) => {
+  const mins = parseInt(duration);
+  if (mins >= 5) return "alert";
+  if (mins >= 3) return "watch";
   return "healthy";
 };
 
@@ -53,191 +74,220 @@ export default function DashboardPage() {
   const selectedCat = useMemo(() => getCatById(selectedCatId), [selectedCatId]);
   const stats = useMemo(() => mockStats[selectedCatId], [selectedCatId]);
 
-  // Check if any cat has an anomaly
-  const hasAnomaly = useMemo(() => {
-    return mockCats.some((cat) => cat.status !== "healthy");
-  }, []);
-
-  // Get first cat with anomaly for the alert banner
-  const alertCat = useMemo(() => {
-    return mockCats.find((cat) => cat.status !== "healthy");
-  }, []);
+  const hasAnomaly = useMemo(() => mockCats.some((cat) => cat.status !== "healthy"), []);
+  const alertCat = useMemo(() => mockCats.find((cat) => cat.status !== "healthy"), []);
 
   const greeting = getGreeting();
   const todayDate = formatDate();
 
   return (
-    <div className="min-h-screen bg-[#FDFAF6] pb-24">
-      {/* Top Navigation */}
+    <div className="min-h-screen bg-litter-bg pb-24">
       <TopBar />
 
-      {/* Main Content */}
-      <main className="pt-20 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto">
-        {/* Greeting Section */}
-        <motion.section
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className="mb-6"
-        >
-          <h1 className="font-display text-2xl sm:text-3xl font-bold text-[#1C1C1C] mb-1">
-            {greeting}, Maria <span className="inline-block">👋</span>
-          </h1>
-          <p className="text-[#6B7280] text-sm sm:text-base">
-            Here's how your cats are doing today.
-          </p>
-          <p className="text-[#6B7280]/70 text-xs mt-1">{todayDate}</p>
-        </motion.section>
+      <main className="pt-20 px-4 sm:px-6 lg:px-8 max-w-6xl mx-auto">
+        {/* Desktop two-column layout */}
+        <div className="lg:grid lg:grid-cols-[320px_1fr] lg:gap-8 lg:items-start">
 
-        {/* Cat Selector */}
-        <motion.section
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.1 }}
-          className="mb-6"
-        >
-          <div className="flex gap-3 overflow-x-auto scrollbar-hide pb-2 -mx-4 px-4 sm:mx-0 sm:px-0">
-            {mockCats.map((cat) => (
-              <CatChip
-                key={cat.id}
-                cat={cat}
-                isActive={selectedCatId === cat.id}
-                onClick={() => setSelectedCatId(cat.id)}
-              />
-            ))}
-          </div>
-        </motion.section>
+          {/* ── LEFT COLUMN: Greeting + Cat Selector + Alert ── */}
+          <div className="lg:sticky lg:top-24 lg:pt-6">
 
-        {/* Health Alert Banner */}
-        <AnimatePresence>
-          {showAlertBanner && hasAnomaly && alertCat && (
-            <motion.div
-              initial={{ opacity: 0, height: 0, marginBottom: 0 }}
-              animate={{ opacity: 1, height: "auto", marginBottom: 24 }}
-              exit={{ opacity: 0, height: 0, marginBottom: 0 }}
-              transition={{ duration: 0.3 }}
-              className="bg-amber-50 border border-amber-200 rounded-2xl p-4 flex items-start gap-3 overflow-hidden"
+            {/* Greeting Section */}
+            <motion.section
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+              className="mb-6 pt-6"
             >
-              <div className="p-2 bg-amber-100 rounded-xl shrink-0">
-                <AlertTriangle className="w-5 h-5 text-amber-600" />
+              <h1 className="font-display text-2xl sm:text-3xl lg:text-4xl font-bold text-litter-text mb-1">
+                {greeting}, Sigma <span className="inline-block">👋</span>
+              </h1>
+              <p className="text-litter-muted text-sm sm:text-base">
+                {hasAnomaly ? "Everything looks mostly okay today." : "Here\u2019s how your cats are doing today."}
+              </p>
+              <p className="text-litter-primary text-xs sm:text-sm font-medium mt-1">{todayDate}</p>
+            </motion.section>
+
+            {/* Cat Selector */}
+            <motion.section
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.1 }}
+              className="mb-6"
+            >
+              <div className="flex flex-wrap gap-2">
+                {mockCats.map((cat) => (
+                  <CatChip
+                    key={cat.id}
+                    cat={cat}
+                    isActive={selectedCatId === cat.id}
+                    onClick={() => setSelectedCatId(cat.id)}
+                  />
+                ))}
               </div>
-              <div className="flex-1 min-w-0">
-                <p className="text-amber-900 font-medium text-sm sm:text-base">
-                  {alertCat.name} has shown unusual litter box behavior today.
-                </p>
-                <p className="text-amber-700/80 text-xs sm:text-sm mt-1">
-                  Consider logging a vet visit.
-                </p>
-                <button className="mt-3 px-4 py-2 bg-white border border-amber-200 text-amber-800 text-sm font-medium rounded-lg hover:bg-amber-50 transition-colors">
-                  View Details
+            </motion.section>
+
+            {/* Health Alert Banner */}
+            <AnimatePresence>
+              {showAlertBanner && hasAnomaly && alertCat && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.3 }}
+                  className="overflow-hidden"
+                >
+                  <div className="bg-amber-50 border border-amber-200 border-l-4 border-l-amber-400 rounded-r-2xl rounded-l-sm p-4 mb-6">
+                    <div className="flex items-start gap-3 mb-3">
+                      <div className="p-2 bg-amber-100 rounded-full shrink-0">
+                        <AlertTriangle className="w-5 h-5 text-amber-500" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-amber-700 font-bold text-sm">
+                          {alertCat.name} - Unusual Behavior
+                        </p>
+                        <p className="text-litter-muted text-xs mt-1">
+                          Unusual litter box behavior detected today. Consider logging a vet visit if symptoms persist.
+                        </p>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => setShowAlertBanner(false)}
+                      className="w-full py-2.5 bg-amber-100 hover:bg-amber-200 text-amber-700 text-sm font-semibold rounded-xl transition-colors border border-amber-200"
+                    >
+                      View Details
+                    </button>
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            {/* Selected cat status summary — desktop only */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.2 }}
+              className="hidden lg:flex items-center justify-between p-4 bg-white rounded-2xl border border-litter-border shadow-sm mb-6"
+            >
+              <div className="flex items-center gap-3">
+                <div className="w-11 h-11 rounded-full bg-litter-primary-light flex items-center justify-center text-litter-primary font-bold text-lg">
+                  {selectedCat?.name.charAt(0).toUpperCase()}
+                </div>
+                <div>
+                  <p className="font-semibold text-litter-text">{selectedCat?.name}</p>
+                  <p className="text-xs text-litter-muted">Currently selected</p>
+                </div>
+              </div>
+              <span
+                className={`text-xs px-3 py-1.5 rounded-full font-semibold ${
+                  selectedCat?.status === "healthy"
+                    ? "bg-green-100 text-green-700"
+                    : selectedCat?.status === "watch"
+                    ? "bg-amber-100 text-amber-700"
+                    : "bg-red-100 text-red-700"
+                }`}
+              >
+                {selectedCat?.status === "healthy" ? "● Healthy" : selectedCat?.status === "watch" ? "● Watch" : "● Alert"}
+              </span>
+            </motion.div>
+          </div>
+
+          {/* ── RIGHT COLUMN: Stats + Activity ── */}
+          <div className="lg:pt-6">
+
+            {/* Stats Section */}
+            <motion.section
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.2 }}
+              className="mb-8"
+            >
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="font-display text-lg sm:text-xl font-semibold text-litter-text">
+                  {selectedCat?.name}&apos;s Stats
+                </h2>
+                {/* Mobile-only status badge */}
+                <span
+                  className={`lg:hidden text-xs px-2 py-1 rounded-full font-medium ${
+                    selectedCat?.status === "healthy"
+                      ? "bg-green-100 text-green-700"
+                      : selectedCat?.status === "watch"
+                      ? "bg-amber-100 text-amber-700"
+                      : "bg-red-100 text-red-700"
+                  }`}
+                >
+                  {selectedCat?.status === "healthy" ? "Healthy" : selectedCat?.status === "watch" ? "Watch" : "Alert"}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 sm:gap-4">
+                <StatCard
+                  icon={Clock}
+                  value={stats?.visits ?? "--"}
+                  label="Today's Visits"
+                  status={getVisitsStatus(stats?.visits ?? 0)}
+                  statusLabel={getVisitsLabel(stats?.visits ?? 0)}
+                  delay={0}
+                />
+                <StatCard
+                  icon={Timer}
+                  value={stats?.avgDuration || "--"}
+                  label="Avg Duration"
+                  status={getDurationStatus(stats?.avgDuration || "")}
+                  statusLabel={getDurationLabel(stats?.avgDuration || "")}
+                  delay={0.1}
+                />
+                <StatCard
+                  icon={Wind}
+                  value={stats?.airQuality || "--"}
+                  label="Air Quality"
+                  status={getAirQualityStatus(stats?.airQuality || "Normal")}
+                  statusLabel={stats?.airQuality === "Normal" ? "Healthy" : stats?.airQuality === "Elevated" ? "Unusual" : "Alert"}
+                  delay={0.2}
+                />
+                <StatCard
+                  icon={BarChart2}
+                  value={`${stats?.litterLevel ?? "--"}%`}
+                  label="Litter Level"
+                  status={getLitterLevelStatus(stats?.litterLevel ?? 0)}
+                  delay={0.3}
+                />
+              </div>
+            </motion.section>
+
+            {/* Recent Activity Feed */}
+            <motion.section
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.3 }}
+            >
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="font-display text-lg sm:text-xl font-semibold text-litter-text">
+                  Recent Activity
+                </h2>
+                <button className="text-litter-primary text-sm font-medium hover:underline">
+                  See all
                 </button>
               </div>
-              <button
-                onClick={() => setShowAlertBanner(false)}
-                className="p-1 text-amber-600 hover:text-amber-800 transition-colors shrink-0"
-              >
-                <X className="w-5 h-5" />
-              </button>
-            </motion.div>
-          )}
-        </AnimatePresence>
 
-        {/* Active Cat Stats Section */}
-        <motion.section
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.2 }}
-          className="mb-8"
-        >
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="font-display text-lg sm:text-xl font-semibold text-[#1C1C1C]">
-              {selectedCat?.name}'s Stats
-            </h2>
-            <span
-              className={`text-xs px-2 py-1 rounded-full font-medium ${
-                selectedCat?.status === "healthy"
-                  ? "bg-green-100 text-green-700"
-                  : selectedCat?.status === "watch"
-                  ? "bg-amber-100 text-amber-700"
-                  : "bg-red-100 text-red-700"
-              }`}
-            >
-              {selectedCat?.status === "healthy"
-                ? "Healthy"
-                : selectedCat?.status === "watch"
-                ? "Watch"
-                : "Alert"}
-            </span>
+              <div className="space-y-3">
+                {mockActivity.map((activity, index) => (
+                  <ActivityItem
+                    key={index}
+                    catId={activity.catId}
+                    action={activity.action}
+                    time={activity.time}
+                    duration={activity.duration}
+                    anomaly={activity.anomaly}
+                    anomalyNote={activity.anomalyNote}
+                    index={index}
+                  />
+                ))}
+              </div>
+            </motion.section>
           </div>
-
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-            <StatCard
-              icon={Clock}
-              value={`${stats?.visits} visits`}
-              label="Today's Visits"
-              status={stats?.visits && stats.visits > 5 ? "watch" : "healthy"}
-              delay={0}
-            />
-            <StatCard
-              icon={Timer}
-              value={stats?.avgDuration || "--"}
-              label="Avg Duration"
-              status={
-                stats?.avgDuration && stats.avgDuration.startsWith("4")
-                  ? "watch"
-                  : "normal"
-              }
-              delay={0.1}
-            />
-            <StatCard
-              icon={Wind}
-              value={stats?.airQuality || "--"}
-              label="Air Quality"
-              status={getAirQualityStatus(stats?.airQuality || "Normal")}
-              delay={0.2}
-            />
-            <StatCard
-              icon={BarChart2}
-              value={`${stats?.litterLevel}% full`}
-              label="Litter Level"
-              status={getLitterLevelStatus(stats?.litterLevel || 0)}
-              delay={0.3}
-            />
-          </div>
-        </motion.section>
-
-        {/* Recent Activity Feed */}
-        <motion.section
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.3 }}
-        >
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="font-display text-lg sm:text-xl font-semibold text-[#1C1C1C]">
-              Recent Activity
-            </h2>
-            <button className="text-[#1E6B5E] text-sm font-medium hover:underline">
-              See all
-            </button>
-          </div>
-
-          <div className="space-y-3">
-            {mockActivity.map((activity, index) => (
-              <ActivityItem
-                key={index}
-                catId={activity.catId}
-                action={activity.action}
-                time={activity.time}
-                anomaly={activity.anomaly}
-                anomalyNote={activity.anomalyNote}
-                index={index}
-              />
-            ))}
-          </div>
-        </motion.section>
+        </div>
       </main>
 
-      {/* Bottom Navigation */}
       <BottomNav />
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,7 +6,7 @@
 
 /* CSS Custom Properties - LitterSense Color Palette */
 :root {
-  --color-bg: #FDFAF6;
+  --color-bg: #F2F4F7;
   --color-primary: #1E6B5E;
   --color-primary-light: #D4EDE8;
   --color-accent: #E8924A;
@@ -28,7 +28,7 @@
   --font-body: 'DM Sans', sans-serif;
   
   /* Colors */
-  --color-litter-bg: #FDFAF6;
+  --color-litter-bg: #F2F4F7;
   --color-litter-primary: #1E6B5E;
   --color-litter-primary-light: #D4EDE8;
   --color-litter-accent: #E8924A;

--- a/components/ui/ActivityItem.tsx
+++ b/components/ui/ActivityItem.tsx
@@ -1,44 +1,38 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { AlertTriangle } from "lucide-react";
 import { getCatById } from "@/lib/mockData";
 
 interface ActivityItemProps {
   catId: string;
   action: string;
   time: string;
+  duration?: string;
   anomaly?: boolean;
   anomalyNote?: string;
   index?: number;
 }
 
-const borderColors = {
-  normal: "border-l-[#1E6B5E]",
-  warning: "border-l-amber-500",
-  alert: "border-l-red-500",
-};
-
 export function ActivityItem({
   catId,
   action,
   time,
+  duration,
   anomaly = false,
   anomalyNote,
   index = 0,
 }: ActivityItemProps) {
   const cat = getCatById(catId);
-  const borderColor = anomaly ? borderColors.warning : borderColors.normal;
 
   return (
     <motion.div
       initial={{ opacity: 0, x: -20 }}
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.3, delay: index * 0.1 }}
-      className={`flex items-center gap-3 p-3 bg-white rounded-xl border border-[#E8E2D9] border-l-4 ${borderColor} shadow-sm`}
+      className="flex items-center gap-3 p-4 bg-white rounded-xl border border-litter-border shadow-sm"
     >
       {/* Cat Avatar */}
-      <div className="w-10 h-10 rounded-full bg-[#D4EDE8] flex items-center justify-center text-[#1E6B5E] font-medium text-sm shrink-0">
+      <div className="w-10 h-10 rounded-full bg-litter-primary-light flex items-center justify-center text-litter-primary font-semibold text-sm shrink-0">
         {cat?.avatar ? (
           <img src={cat.avatar} alt={cat?.name} className="w-full h-full rounded-full object-cover" />
         ) : (
@@ -48,19 +42,23 @@ export function ActivityItem({
 
       {/* Content */}
       <div className="flex-1 min-w-0">
-        <p className="text-[#1C1C1C] font-medium text-sm">
-          <span className="font-semibold">{cat?.name}</span> {action}
+        <p className="text-litter-text font-semibold text-sm">
+          {cat?.name} {action}
         </p>
-        <p className="text-[#6B7280] text-xs mt-0.5">{time}</p>
+        {duration && (
+          <p className="text-litter-muted text-xs mt-0.5">Duration: {duration}</p>
+        )}
       </div>
 
-      {/* Anomaly Badge */}
-      {anomaly && (
-        <div className="flex items-center gap-1 px-2 py-1 bg-amber-100 text-amber-700 rounded-lg text-xs font-medium shrink-0">
-          <AlertTriangle className="w-3 h-3" />
-          <span className="hidden sm:inline">{anomalyNote || "Alert"}</span>
-        </div>
-      )}
+      {/* Right side: time + anomaly badge */}
+      <div className="flex items-center gap-2 shrink-0">
+        {anomaly && (
+          <span className="px-2.5 py-1 bg-amber-100 text-amber-700 rounded-lg text-xs font-semibold uppercase tracking-wide">
+            {anomalyNote || "Unusual"}
+          </span>
+        )}
+        <span className="text-litter-muted text-xs">{time}</span>
+      </div>
     </motion.div>
   );
 }

--- a/components/ui/StatCard.tsx
+++ b/components/ui/StatCard.tsx
@@ -8,43 +8,57 @@ interface StatCardProps {
   value: string | number;
   label: string;
   status?: "healthy" | "watch" | "alert" | "normal";
+  statusLabel?: string;
   delay?: number;
 }
 
-const statusColors = {
-  healthy: "bg-green-100 text-green-600 border-green-200",
-  watch: "bg-amber-100 text-amber-600 border-amber-200",
-  alert: "bg-red-100 text-red-600 border-red-200",
-  normal: "bg-[#D4EDE8] text-[#1E6B5E] border-[#1E6B5E]/20",
+const iconColors = {
+  healthy: "text-[#1E6B5E]",
+  watch:   "text-amber-500",
+  alert:   "text-red-500",
+  normal:  "text-[#1E6B5E]",
 };
 
 const statusBarColors = {
-  healthy: "bg-green-500",
-  watch: "bg-amber-500",
-  alert: "bg-red-500",
-  normal: "bg-[#1E6B5E]",
+  healthy: "bg-[#1E6B5E]",
+  watch:   "bg-amber-500",
+  alert:   "bg-red-500",
+  normal:  "bg-[#1E6B5E]",
 };
 
-export function StatCard({ icon: Icon, value, label, status = "normal", delay = 0 }: StatCardProps) {
+const statusLabelColors = {
+  healthy: "text-[#1E6B5E]",
+  watch:   "text-amber-500",
+  alert:   "text-red-500",
+  normal:  "text-[#1E6B5E]",
+};
+
+export function StatCard({ icon: Icon, value, label, status = "normal", statusLabel, delay = 0 }: StatCardProps) {
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4, delay, ease: [0.25, 0.46, 0.45, 0.94] }}
-      className="bg-white rounded-2xl p-4 sm:p-5 shadow-sm border border-[#E8E2D9] relative overflow-hidden"
+      className="bg-white rounded-2xl p-4 sm:p-5 shadow-sm border border-litter-border relative overflow-hidden"
     >
-      <div className="flex items-start gap-3">
-        <div className={`p-2.5 rounded-xl ${statusColors[status]}`}>
-          <Icon className="w-5 h-5 sm:w-6 sm:h-6" />
-        </div>
-        <div className="flex-1 min-w-0">
-          <p className="text-2xl sm:text-3xl font-bold text-[#1C1C1C] font-display tracking-tight">
-            {value}
-          </p>
-          <p className="text-sm text-[#6B7280] mt-0.5">{label}</p>
-        </div>
+      {/* Top row: icon left, status label right */}
+      <div className="flex items-center justify-between mb-3">
+        <Icon className={`w-6 h-6 ${iconColors[status]}`} />
+        {statusLabel && (
+          <span className={`text-xs font-semibold tracking-wide uppercase ${statusLabelColors[status]}`}>
+            {statusLabel}
+          </span>
+        )}
       </div>
-      
+
+      {/* Value */}
+      <p className="text-2xl sm:text-3xl font-bold text-litter-text font-display tracking-tight leading-none">
+        {value}
+      </p>
+
+      {/* Label */}
+      <p className="text-sm text-litter-muted mt-1">{label}</p>
+
       {/* Status indicator bar */}
       <div className={`absolute bottom-0 left-0 right-0 h-1 ${statusBarColors[status]}`} />
     </motion.div>

--- a/lib/mockData.ts
+++ b/lib/mockData.ts
@@ -10,12 +10,14 @@ export interface CatStats {
   avgDuration: string;
   airQuality: "Normal" | "Elevated" | "Poor";
   litterLevel: number;
+  lastVisit: string;
 }
 
 export interface ActivityItemData {
   catId: string;
   action: string;
   time: string;
+  duration?: string;
   anomaly: boolean;
   anomalyNote?: string;
 }
@@ -64,28 +66,28 @@ export interface PastReport {
 }
 
 export const mockCats: Cat[] = [
-  { id: "1", name: "Mochi", status: "healthy", avatar: null },
-  { id: "2", name: "Luna", status: "watch", avatar: null },
-  { id: "3", name: "Tigger", status: "alert", avatar: null },
+  { id: "1", name: "Mochi", status: "watch", avatar: null },
+  { id: "2", name: "Luna", status: "healthy", avatar: null },
+  { id: "3", name: "Tigger", status: "healthy", avatar: null },
 ];
 
 export const mockStats: Record<string, CatStats> = {
-  "1": { visits: 4, avgDuration: "2m 14s", airQuality: "Normal", litterLevel: 68 },
-  "2": { visits: 7, avgDuration: "4m 01s", airQuality: "Elevated", litterLevel: 45 },
-  "3": { visits: 2, avgDuration: "1m 30s", airQuality: "Normal", litterLevel: 80 },
+  "1": { visits: 8,  avgDuration: "30m",  airQuality: "Elevated", litterLevel: 55, lastVisit: "Sep 28" },
+  "2": { visits: 12, avgDuration: "45m",  airQuality: "Normal",   litterLevel: 42, lastVisit: "Oct 12" },
+  "3": { visits: 4,  avgDuration: "20m",  airQuality: "Normal",   litterLevel: 80, lastVisit: "Oct 05" },
 };
 
 export const mockActivity: ActivityItemData[] = [
-  { catId: "1", action: "visited the litter box", time: "12 minutes ago", anomaly: false },
-  { catId: "2", action: "visited the litter box", time: "34 minutes ago", anomaly: true, anomalyNote: "Unusual duration" },
-  { catId: "1", action: "visited the litter box", time: "1 hour ago", anomaly: false },
-  { catId: "3", action: "visited the litter box", time: "2 hours ago", anomaly: false },
+  { catId: "1", action: "visited", time: "12m ago", duration: "1m 45s", anomaly: false },
+  { catId: "2", action: "visited", time: "34m ago", duration: "2m 10s", anomaly: false },
+  { catId: "3", action: "visited", time: "1h ago",  duration: "1m 12s", anomaly: false },
+  { catId: "1", action: "visited", time: "2h ago",  duration: "8m",     anomaly: true, anomalyNote: "Unusual duration" },
 ];
 
 export const mockCatDetails: Record<string, CatDetails> = {
   "1": {
-    breed: "Domestic Shorthair",
-    dob: "2022-03",
+    breed: "Tabby",
+    dob: "2021-03",
     weightKg: 4.2,
     rfidTag: "A1B2C3D4",
     baseline: {
@@ -97,8 +99,8 @@ export const mockCatDetails: Record<string, CatDetails> = {
     }
   },
   "2": {
-    breed: "Persian Mix",
-    dob: "2021-07",
+    breed: "Siamese",
+    dob: "2023-03",
     weightKg: 3.8,
     rfidTag: "E5F6G7H8",
     baseline: {
@@ -110,8 +112,8 @@ export const mockCatDetails: Record<string, CatDetails> = {
     }
   },
   "3": {
-    breed: "Siamese",
-    dob: "2020-11",
+    breed: "Bombay",
+    dob: "2024-03",
     weightKg: 3.5,
     rfidTag: "I9J0K1L2",
     baseline: {


### PR DESCRIPTION
- Adapt dashboard and cats pages to match wireframe layout and colors
- Two-column desktop layout for dashboard with sticky left sidebar
- Redesign cat cards with VISITS / DURATION / LAST VISIT stats row
- Update stat cards with plain colored icons and status labels
- Restyle alert banner with thick left border design
- Update mock data to match wireframe values (breeds, ages, stats)
- Change background to cool gray (#F2F4F7) to match wireframe