### PR TITLE
3A-G05-W001-PR01. Deprecation of React.FormEvent

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -30,7 +30,7 @@ export default function ForgotPasswordPage() {
     }
   }, [user, authLoading, router]);
 
-  const handleSubmit = async (event: React.FormEvent) => {
+  const handleSubmit = async (event: React.SubmitEvent) => {
     event.preventDefault();
     setIsLoading(true);
     setError("");

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -48,7 +48,7 @@ export default function LoginPage() {
     }
   }, [user, authLoading, isAdmin, router]);
 
-  const handleSubmit = async (event: React.FormEvent) => {
+  const handleSubmit = async (event: React.SubmitEvent) => {
     event.preventDefault();
     setIsLoading(true);
     setError("");

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -35,7 +35,7 @@ export default function SignUpPage() {
     }
   }, [user, authLoading, isAdmin, router]);
 
-  const handleSubmit = async (event: React.FormEvent) => {
+  const handleSubmit = async (event: React.SubmitEvent) => {
     event.preventDefault();
     setError("");
     if (password !== confirmPassword) {


### PR DESCRIPTION
## Summary
- Replaced all instances of `React.FormEvent` with `React.SubmitEvent` in auth pages.
- Needed because `React.FormEvent` is deprecated for form submit events.

## Changes
- Updated `app/(auth)/forgot-password/page.tsx` (L32)
- Updated `app/(auth)/login/page.tsx` (L50)
- Updated `app/(auth)/signup/page.tsx` (L37)

## Checklist
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.