### PR TITLE
3A-G05-W006-PR02. Dynamic Page Titles

### DIFF
--- a/app/(auth)/forgot-password/check-email/layout.tsx
+++ b/app/(auth)/forgot-password/check-email/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Check Email",
+};
+
+export default function CheckEmailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/(auth)/forgot-password/layout.tsx
+++ b/app/(auth)/forgot-password/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: {
+    default: "Forgot Password | LitterSense",
+    template: "%s | LitterSense",
+  },
+};
+
+export default function ForgotPasswordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -34,7 +34,7 @@ export default function ForgotPasswordPage() {
     event.preventDefault();
     setIsLoading(true);
     setError("");
-
+    
     try {
       await sendPasswordResetEmail(auth, email);
       router.push(
@@ -91,7 +91,7 @@ export default function ForgotPasswordPage() {
                 {error}
               </div>
             )}
-
+            
             {/* Email Field */}
             <div>
               <label

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Login",
+};
+
+export default function LoginLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/(auth)/signup/layout.tsx
+++ b/app/(auth)/signup/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign Up",
+};
+
+export default function SignupLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { AdminRoute } from "@/components/AdminRoute";
+
+export const metadata: Metadata = {
+  title: "Admin",
+};
 
 export default function AdminLayout({
   children,

--- a/app/dashboard/cats/[catId]/layout.tsx
+++ b/app/dashboard/cats/[catId]/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Cat Details",
+};
+
+export default function CatDetailsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/dashboard/cats/layout.tsx
+++ b/app/dashboard/cats/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: {
+    default: "My Cats",
+    template: "%s | LitterSense",
+  },
+};
+
+export default function CatsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { RfidVisitBridge } from "@/components/dashboard/RfidVisitBridge";
+
+export const metadata: Metadata = {
+  title: {
+    default: "Home",
+    template: "%s | LitterSense",
+  },
+};
 
 export default function DashboardLayout({
   children,

--- a/app/dashboard/notifications/layout.tsx
+++ b/app/dashboard/notifications/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Notifications",
+};
+
+export default function NotificationsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/dashboard/playback/layout.tsx
+++ b/app/dashboard/playback/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Playback",
+};
+
+export default function PlaybackLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/dashboard/reports/layout.tsx
+++ b/app/dashboard/reports/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Reports",
+};
+
+export default function ReportsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/dashboard/settings/layout.tsx
+++ b/app/dashboard/settings/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Settings",
+};
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,10 +4,14 @@ import { AuthProvider } from "@/lib/contexts/AuthContext";
 import { CatProvider } from "@/lib/contexts/CatContext";
 import { NotificationProvider } from "@/lib/contexts/NotificationContext";
 import { DeleteRequestProvider } from "@/lib/contexts/DeleteRequestContext";
+
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "LitterSense - Feline Health Monitoring",
+  title: {
+    default: "Login | LitterSense",
+    template: "%s | LitterSense",
+  },
   description: "IoT-enabled feline health monitoring for Filipino cat owners. Early detection, healthier cats.",
   manifest: "/manifest.json",
   icons: {
@@ -17,7 +21,6 @@ export const metadata: Metadata = {
   appleWebApp: {
     capable: true,
     statusBarStyle: "default",
-    title: "LitterSense",
   },
 };
 


### PR DESCRIPTION
## Summary
- Added route-specific page titles using Next.js static metadata.
- Needed so browser tab titles update correctly per route and follow the Next.js metadata standard.

## Changes
- Updated `app/layout.tsx` with a shared title template.
- Added static metadata layouts for auth, dashboard, admin, and dashboard subpages.
- Removed reliance on client-side `document.title` updates.
- Ensured titles use the format `Page Name | LitterSense`.

## Checklist
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.
